### PR TITLE
Pulled nag_triggered declaration outside of if block.  

### DIFF
--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -604,6 +604,8 @@ def main():
     if not os.path.exists(umad_tmp_dir):
         os.makedirs(umad_tmp_dir)
 
+    nag_triggered = False
+    
     if skip_nag_check:
         # Trick logic into thinking device isn't DEP capable
         dep_capable = False
@@ -641,8 +643,6 @@ def main():
         else:
             dep_capable = False
             print 'Device DEP capable - False'
-
-        nag_triggered = False
 
         if dep_capable:
             # Trigger Nag event


### PR DESCRIPTION
Code further down could use the variable and errors if it hasn't been initialized yet.

I tested this code in the scenario I had where a machine had an MDM profile already installed but in an non-UAMDM state.  The system was not DEP eligible so no testing has been done with DEP included.