### PR TITLE
Run script after UI quits

### DIFF
--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -76,10 +76,12 @@ def button_understand():
     umad.views['button.ok'].setEnabled_(True)
 
 
-def check_mdm_status(umadupdate):
+def check_mdm_status(umadupdate, script=None):
     '''Check MDM Status'''
     uamdm_enrolled = False
     mdm_enrolled = False
+    print script  ####DEBUG REMOVE
+    print 'umadupdate: %s' % umadupdate  ####DEBUG REMOVE
     # Check the OS and run our dep checks based on OS version
     if get_os_version() >= LooseVersion('10.13.4'):
         print 'Checking mdm status - modern'
@@ -87,6 +89,9 @@ def check_mdm_status(umadupdate):
             print 'MDM enrolled device %s' % get_os_version()
             uamdm_enrolled = True
             if umadupdate:
+                if script is not None:
+                    print 'UAMDM accepted.  Running %s' % script
+                    run_arbitrary_script(script)
                 umad.quit()
         else:
             # Check if MDM is installed.
@@ -362,6 +367,8 @@ def get_parsed_options():
     o.add_option('--profileidentifier',
                  default='B68ABF1E-70E2-43B0-8300-AE65F9AFA330',
                  help=('Required: MDM profile identifier.'))
+    o.add_option('--scriptwhenuiquits',
+                 help=('Optional: Script to run when UI exists.'))
     o.add_option('--subtitletext',
                  default='A friendly reminder from your local IT team',
                  help=('Required: Sub-title text.'))
@@ -526,6 +533,17 @@ def update_umad_ui_uamdm(uamdm_p1, uamdm_p2, uamdm_p3):
     umad.views['field.depfailuresubtext'].setStringValue_(sysprefs_h2_text.decode('utf8'))
 
 
+def run_arbitrary_script(script_path=None):
+    '''Run a provided script'''
+    if script_path:
+        if os.path.exists(script_path):
+                run = subprocess.Popen(script_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                output, err = run.communicate()
+                print output
+        else:
+            print "File {} was not found".format(filename)
+    
+
 def main():
     '''Main thread'''
     opts, _ = get_parsed_options()
@@ -542,7 +560,7 @@ def main():
         print 'WARN - Did not set mdm profile identifier!'
 
     # Check the OS and run our dep checks based on OS version
-    mdm_status = check_mdm_status(False)
+    mdm_status = check_mdm_status(False, opts.scriptwhenuiquits)
     uamdm_enrolled = mdm_status[0]
     mdm_enrolled = mdm_status[1]
 
@@ -910,7 +928,7 @@ def main():
             opts.depfailuresubtext.decode('utf8'))
 
     # Do one final MDM check to instantly update the UI for UAMDM
-    check_mdm_status(True)
+    check_mdm_status(True, opts.scriptwhenuiquits)
 
     umad.run()
 

--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -539,7 +539,7 @@ def run_arbitrary_script(script_path=None):
                 output, err = run.communicate()
                 print output
         else:
-            print "File {} was not found".format(filename)
+            print "File {} was not found".format(script_path)
     
 
 def main():

--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -76,12 +76,10 @@ def button_understand():
     umad.views['button.ok'].setEnabled_(True)
 
 
-def check_mdm_status(umadupdate, script=None):
+def check_mdm_status(umadupdate):
     '''Check MDM Status'''
     uamdm_enrolled = False
     mdm_enrolled = False
-    print script  ####DEBUG REMOVE
-    print 'umadupdate: %s' % umadupdate  ####DEBUG REMOVE
     # Check the OS and run our dep checks based on OS version
     if get_os_version() >= LooseVersion('10.13.4'):
         print 'Checking mdm status - modern'
@@ -89,9 +87,9 @@ def check_mdm_status(umadupdate, script=None):
             print 'MDM enrolled device %s' % get_os_version()
             uamdm_enrolled = True
             if umadupdate:
-                if script is not None:
-                    print 'UAMDM accepted.  Running %s' % script
-                    run_arbitrary_script(script)
+                if script_when_ui_quits is not None:
+                    print 'UAMDM accepted.  Running %s' % script_when_ui_quits
+                    run_arbitrary_script(script_when_ui_quits)
                 umad.quit()
         else:
             # Check if MDM is installed.
@@ -535,7 +533,7 @@ def update_umad_ui_uamdm(uamdm_p1, uamdm_p2, uamdm_p3):
 
 def run_arbitrary_script(script_path=None):
     '''Run a provided script'''
-    if script_path:
+    if script_path is not None:
         if os.path.exists(script_path):
                 run = subprocess.Popen(script_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 output, err = run.communicate()
@@ -560,7 +558,7 @@ def main():
         print 'WARN - Did not set mdm profile identifier!'
 
     # Check the OS and run our dep checks based on OS version
-    mdm_status = check_mdm_status(False, opts.scriptwhenuiquits)
+    mdm_status = check_mdm_status(False)
     uamdm_enrolled = mdm_status[0]
     mdm_enrolled = mdm_status[1]
 
@@ -610,6 +608,8 @@ def main():
     manualenroll_h1_text = opts.manualenrollh1text
     global manualenroll_h2_text
     manualenroll_h2_text = opts.manualenrollh2text
+    global script_when_ui_quits
+    script_when_ui_quits = opts.scriptwhenuiquits
 
     # Get the current username
     user_name, current_user_uid, _ = get_console_username_info()
@@ -928,7 +928,7 @@ def main():
             opts.depfailuresubtext.decode('utf8'))
 
     # Do one final MDM check to instantly update the UI for UAMDM
-    check_mdm_status(True, opts.scriptwhenuiquits)
+    check_mdm_status(True)
 
     umad.run()
 

--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -366,7 +366,7 @@ def get_parsed_options():
                  default='B68ABF1E-70E2-43B0-8300-AE65F9AFA330',
                  help=('Required: MDM profile identifier.'))
     o.add_option('--scriptwhenuiquits',
-                 help=('Optional: Script to run when UI exists.'))
+                 help=('Optional: Script to run when UI exits.'))
     o.add_option('--subtitletext',
                  default='A friendly reminder from your local IT team',
                  help=('Required: Sub-title text.'))


### PR DESCRIPTION
This change allows an admin to set an Optional option of `--scriptwhenuiquits` to run a script after the UMAD UI disappears signaling the machine is now UAMDMed.

I tested this in UMAD with a manual enrollment workflow and a non-UAMDMed machine that had the enrollment profile installed but not approved yet.  Both fired off the script on exit.
