### PR TITLE
Skip notification DB entries without dates

### DIFF
--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -269,6 +269,11 @@ def get_all_notifications_modern():
                 plist_data = plist['req']
                 date = row['delivered_date']
                 date_time = datetime.utcfromtimestamp(date + 978307200)
+                if date == None: 
+                  # This avoids a type error for apps that put entries with 
+                  # blank delivery dates in the notification DB for syncing purposes. 
+                  # We don't care about those anyway.
+                  continue
                 app = row['app']
                 title = plist_data.get('titl', '')
                 message = plist_data.get('body', '')


### PR DESCRIPTION
I discovered that Things.app creates entries in the com.apple.notificationcenter database with a Null date field, which causes a TypeError which drives you to Manual Enrollment even after successfully prompting a DEP nag. Don't know if other apps do this, but it seems safe to ignore entries without a date.