### PR TITLE
Added alternative 3rd paragraph for manual enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ Configure the Manual Enrollment button with a custom URL.
 <string>https://apple.com</string>
 ```
 
+### Manual enrollment paragraph 3 text
+This is the text for the third paragraph on the manual enrollment UI.
+```xml
+<string>--manualenrollparagraph3</string>
+<string>To enroll, download the profile using the button below, and click Install. Once prompted, log in with your username and password.</string>
+```
+
 ### More info URL
 When you see the Manual Enrollment button, you can customize a URL directing the users to more information.
 ```xml
@@ -195,7 +202,7 @@ This is the text for the second paragraph. 160 character limit.
 <string>To enroll, just look for the below notification, and click Details. Once prompted, log in with your username and password.</string>
 ```
 
-### Paragraph 2 text
+### Paragraph 3 text
 This is the text for the third paragraph. 160 character limit.
 ```xml
 <string>--paragraph3</string>

--- a/payload/Library/Application Support/umad/Resources/umad
+++ b/payload/Library/Application Support/umad/Resources/umad
@@ -341,6 +341,11 @@ def get_parsed_options():
     o.add_option('--manualenrollh2text',
                  default='Click on the Manual Enrollment button below.',
                  help=('Optional: Manual enrollment text.'))
+    o.add_option('--manualenrollparagraph3',
+                 default='To enroll, download the profile using the button '
+                 'below, and click Install. Once prompted, log in with '
+                 'your username and password.',
+                 help=('Required: Manual enrollment paragraph 3 text.'))
     o.add_option('--moreinfourl',
                  default='https://google.com',
                  help=('Required: More info URL.'))
@@ -777,6 +782,8 @@ def main():
             umad.views['button.understand'].setHidden_(True)
 
             # Show the manual enrollment UI for emergency purposes
+            umad.views['field.paragraph3'].setStringValue_(
+                opts.manualenrollparagraph3.decode('utf8'))
             umad.views['button.manualenrollment'].setHidden_(False)
             umad.views['field.manualenrollmenttext'].setHidden_(False)
             umad.views['image.nagscreen'].setHidden_(True)
@@ -896,6 +903,8 @@ def main():
     # Also if admin always wants the break glass option
     # Also enable if dep nag didn't actually pop-up
     if (not dep_capable and mdm_profile_set) or opts.enableenrollmentbutton or not nag_triggered:
+        umad.views['field.paragraph3'].setStringValue_(
+            opts.manualenrollparagraph3.decode('utf8'))
         umad.views['button.manualenrollment'].setHidden_(False)
         umad.views['field.manualenrollmenttext'].setHidden_(False)
         umad.views['image.nagscreen'].setHidden_(True)

--- a/payload/Library/LaunchAgents/com.erikng.umad.plist
+++ b/payload/Library/LaunchAgents/com.erikng.umad.plist
@@ -39,6 +39,8 @@
 		<!--<string>Want this box to go away?</string> -->
 		<!--<string>--manualenrollh2text</string> -->
 		<!--<string>Click on the Manual Enrollment button below.</string> -->
+		<!--<string>--manualenrollparagraph3</string> -->
+		<!--<string>To enroll, download the profile using the button below, and click Install. Once prompted, log in with your username and password.</string> -->
 		<!--<string>--paragraph1</string> -->
 		<!--<string>Enrollment into MDM is required to ensure that IT can protect your computer with basic security necessities like encryption and threat detection.</string> -->
 		<!--<string>--paragraph2</string> -->


### PR DESCRIPTION
It's hard to word the third paragraph in a way that makes sense both for the DEP nag and needing to download the profile manually. This splits it into two options, without creating a new NSTextField object.